### PR TITLE
Els dos usuaris ja poden veure els xats anteriors

### DIFF
--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -97,9 +97,11 @@ class ChatController extends Controller
     }
 
     /**
-     * Aquest mètode retorna els missatges que hi ha hagut entre dos usuaris
+     * Aquest mètode retorna, donada la id de l'altre usuari, 
+     * els missatges que hi ha hagut entre ell i qui ha fet la petició
      */
-    public function get_messages_between($other_id) {
+    public function get_messages_between($token) {
+        $other_id = $this->get_reciever($token);
         $messages = Message::where(['sentby_id' => Auth::id(), 'sento_id' => $other_id])
         ->orWhere(['sentby_id' => $other_id, 'sento_id' => Auth::id()])->get();
         $messagesToSend = [];

--- a/resources/vue/Chat.vue
+++ b/resources/vue/Chat.vue
@@ -66,6 +66,7 @@ export default {
                             console.log(`Acabo d'entrar a la sala ${res.token}`)
                             console.log(users)
                             this.actualToken = res.token
+                            this.getMessagesBetween()
                         })
                         .listen('NewMessage', (message) => {
                             console.log('Missatge rebut!', message)
@@ -115,8 +116,8 @@ export default {
                     this.showMessage(message)
                 })
         },
-        async getMessagesBetween(id) {
-            let res = await axios.get('/messages-between/' + id)
+        async getMessagesBetween() {
+            let res = await axios.get('/messages-between/' + this.actualToken)
             let messages = res.data
             messages.forEach(m => {
                 this.printMessage(m.sender, m.text)

--- a/routes/web.php
+++ b/routes/web.php
@@ -128,7 +128,7 @@ Route::get('/me', function() {
 
 Route::get('/channels', [ChatController::class, 'get_channels'])->middleware(['auth', 'verified', 'check_access']);
 
-Route::get('/messages-between/{user_id}', [ChatController::class, 'get_messages_between'])->middleware(['auth', 'verified', 'check_access']);
+Route::get('/messages-between/{token}', [ChatController::class, 'get_messages_between'])->middleware(['auth', 'verified', 'check_access']);
 
 // Aquestes rutes són per accedir als dos murs
 Route::get('discover')->middleware(['auth', 'verified', 'check_access']);


### PR DESCRIPTION
Ara, quan els dos usuaris intenten iniciar un xat, tant el que el vol iniciar com el que rep la invitació veuen automàticament els missatges anteriors